### PR TITLE
Bump v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # InfrastructureSystems
+### 0.1.4
+- Bugfix: Changed the use of get_data to get_time series in get_forecast_value 577f5e2
 
 ### 0.1.3
 - Fix strip_module_names #16

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InfrastructureSystems"
 uuid = "2cd47ed4-ca9b-11e9-27f2-ab636a7671f1"
 authors = ["Daniel Thom", "Jose Daniel Lara", "Clayton Barrows"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"


### PR DESCRIPTION
Found a bug in get_forecast_value. I pushed to master by mistake the fix 577f5e2. 