### PR TITLE
Fix parsing of timeseries data when metadata is stored in CSV.

### DIFF
--- a/src/forecast_parser.jl
+++ b/src/forecast_parser.jl
@@ -59,7 +59,7 @@ function read_time_series_metadata(file_path::AbstractString)
             push!(metadata, TimeseriesFileMetadata(row.Simulation,
                                                    row.Category,
                                                    row.Object,
-                                                   item["label"],
+                                                   row.Parameter,
                                                    row[Symbol("Scaling Factor")],
                                                    row[Symbol("Data File")],
                                                    # TODO: update CDM data for the next

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -336,7 +336,12 @@ function add_forecast_info!(forecast_cache::ForecastCache, metadata::TimeseriesF
 end
 
 """
-    generate_initial_times(data::SystemData, interval::Dates.Period, horizon::Int)
+    generate_initial_times(
+                           data::SystemData,
+                           interval::Dates.Period,
+                           horizon::Int;
+                           initial_time::Union{Nothing, Dates.DateTime}=nothing,
+                          )
 
 Generates all possible initial times for the stored forecasts. This should return the same
 result regardless of whether the forecasts have been stored as one contiguous array or
@@ -344,11 +349,24 @@ chunks of contiguous arrays, such as one 365-day forecast vs 365 one-day forecas
 
 Throws ArgumentError if there are no forecasts stored, interval is not a multiple of the
 system's forecast resolution, or if the stored forecasts have overlapping timestamps.
+
+# Arguments
+- `data::SystemData`: system
+- `interval::Dates.Period`: Amount of time in between each initial time.
+- `horizon::Int`: Length of each forecast array.
+- `initial_time::Union{Nothing, Dates.DateTime}=nothing`: Start with this time. If nothing,
+  use the first initial time.
 """
-function generate_initial_times(data::SystemData, interval::Dates.Period, horizon::Int)
+function generate_initial_times(
+                                data::SystemData,
+                                interval::Dates.Period,
+                                horizon::Int;
+                                initial_time::Union{Nothing, Dates.DateTime}=nothing,
+                               )
     for component in iterate_components_with_forecasts(data.components)
         if has_forecasts(component)
-            return generate_initial_times(component, interval, horizon)
+            return generate_initial_times(component, interval, horizon;
+                                          initial_time=initial_time)
         end
     end
 


### PR DESCRIPTION
@claytonpbarrows @jd-lara Sorry for this, but my earlier PR introduced a regression.  You'll hit a bug if you try to parse time series data from timeseries_pointers.csv instead of timeseries_pointers.json.  All of our test data uses JSON but the RTS_GMLC repo uses CSV.  We need a test to cover CSV; I'll add one to PowerSystems.