### PR TITLE
Support ext inside InfrastructureSystemsInternal

### DIFF
--- a/src/internal.jl
+++ b/src/internal.jl
@@ -2,14 +2,30 @@
 import UUIDs
 
 """Internal storage common to InfrastructureSystems types."""
-struct InfrastructureSystemsInternal
+mutable struct InfrastructureSystemsInternal
     uuid::Base.UUID
+    ext::Union{Nothing, Dict{String, Any}}
 end
 
-"""Creates PowerSystemInternal with a UUID."""
-InfrastructureSystemsInternal() = InfrastructureSystemsInternal(UUIDs.uuid4())
+"""
+Creates PowerSystemInternal with a UUID.
+"""
+InfrastructureSystemsInternal() = InfrastructureSystemsInternal(UUIDs.uuid4(), nothing)
 
-"""Gets the UUID for any PowerSystemType."""
+"""
+Return a user-modifiable dictionary to store extra information.
+"""
+function get_ext(obj::InfrastructureSystemsInternal)
+    if isnothing(obj.ext)
+        obj.ext = Dict{String, Any}()
+    end
+
+    return obj.ext
+end
+
+"""
+Gets the UUID for any PowerSystemType.
+"""
 function get_uuid(obj::InfrastructureSystemsType)::Base.UUID
     return obj.internal.uuid
 end

--- a/test/test_internal.jl
+++ b/test/test_internal.jl
@@ -1,0 +1,11 @@
+@testset "Test ext" begin
+    internal = IS.InfrastructureSystemsInternal()
+    @test isnothing(internal.ext)
+    ext = IS.get_ext(internal)
+    ext["my_value"] = 1
+    @test IS.get_ext(internal)["my_value"] == 1
+
+    internal2 = JSON2.read(JSON2.write(internal), IS.InfrastructureSystemsInternal)
+    @test internal.uuid == internal2.uuid
+    @test internal.ext == internal2.ext
+end

--- a/test/test_system_data.jl
+++ b/test/test_system_data.jl
@@ -33,6 +33,3 @@
 
     @test_throws ArgumentError IS.remove_components!(IS.TestComponent, data)
 end
-
-@testset "Test forecasts" begin
-end


### PR DESCRIPTION
I was asked to add `ext` to PowerSystems.System but in a way that could easily be extended for other systems.  I decided to go a bit more generic.  This is basically a fully-fleshed-out version of what I proposed in our meeting last week.

This is a proposal to allow storage of user-modifiable data inside any type that has an InfrastructureSystemsInternal instance.  By default, `ext` is `nothing`.  If someone defines the `get_ext` method on that type and then the user calls `get_ext` on an instance, the code will initialize `ext` to a dictionary and return it.  The user can then store whatever they want inside it (as long it's String => Any).

Pros:

- This is extremely simple to write and maintain.
- It gives the user the flexibility to do what they want.  If they don't need `ext`, there is virtually no cost.

Cons:

- Maybe this is too much flexibility.  I did consider an option where someone has to call a method `init_ext` in order to change `ext` from nothing to a Dict.  That could be done in an inner constructor for a type containing `internal`.  We could still do that.