### PR TITLE
Ignore line endings when comparing generated structs

### DIFF
--- a/src/utils/generate_structs.jl
+++ b/src/utils/generate_structs.jl
@@ -177,3 +177,31 @@ function generate_structs(
     data = read_json_data(input_file)
     generate_structs(output_directory, data, print_results = print_results)
 end
+
+"""
+    test_generated_structs(descriptor_file, existing_dir)
+
+Return true if the structs defined in existing_dir match structs freshly-generated
+from descriptor_file.
+"""
+function test_generated_structs(descriptor_file, existing_dir)
+    output_dir = "tmp-test-generated-structs"
+    if isdir(output_dir)
+        rm(output_dir; recursive = true)
+    end
+    mkdir(output_dir)
+
+    generate_structs(descriptor_file, output_dir; print_results = false)
+
+    matched = true
+    try
+        run(`diff --strip-trailing-cr $output_dir $existing_dir`)
+    catch err
+        @error "Generated structs do not match the descriptor file." err
+        matched = false
+    finally
+        rm(output_dir; recursive = true)
+    end
+
+    return matched
+end

--- a/test/test_generate_structs.jl
+++ b/test/test_generate_structs.jl
@@ -11,10 +11,9 @@
 
     matched = true
     try
-        run(`diff $output_dir $existing_dir`)
-    catch
-        (err)
-        @error "Generated structs do not match the descriptor file."
+        run(`diff --strip-trailing-cr $output_dir $existing_dir`)
+    catch err
+        @error "Generated structs do not match the descriptor file." err
         matched = false
     finally
         rm(output_dir; recursive = true)

--- a/test/test_generate_structs.jl
+++ b/test/test_generate_structs.jl
@@ -1,23 +1,5 @@
 @testset "Test generated structs" begin
     descriptor_file = joinpath(@__DIR__, "..", "src", "descriptors", "structs.json")
     existing_dir = joinpath(@__DIR__, "..", "src", "generated")
-    output_dir = "tmp-test-generated-structs"
-    if isdir(output_dir)
-        rm(output_dir; recursive = true)
-    end
-    mkdir(output_dir)
-
-    IS.generate_structs(descriptor_file, output_dir; print_results = false)
-
-    matched = true
-    try
-        run(`diff --strip-trailing-cr $output_dir $existing_dir`)
-    catch err
-        @error "Generated structs do not match the descriptor file." err
-        matched = false
-    finally
-        rm(output_dir; recursive = true)
-    end
-
-    @test matched
+    @test IS.test_generated_structs(descriptor_file, existing_dir)
 end


### PR DESCRIPTION
This fixes failures on Travis Windows systems.  It also allows other packages to use the same code for validating generated structs.